### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+# Source: https://github.com/per1234/.github/blob/main/workflow-templates/spell-check.md
+name: Spell Check
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 :floppy_disk: `l3xz_sweep_scanner`
 ==================================
 [![Build Status](https://github.com/107-systems/l3xz_sweep_scanner/actions/workflows/ros2.yml/badge.svg)](https://github.com/107-systems/l3xz_sweep_scanner/actions/workflows/ros2.yml)
+[![Spell Check status](https://github.com/107-systems/l3xz_sweep_scanner/actions/workflows/spell-check.yml/badge.svg)](https://github.com/107-systems/l3xz_sweep_scanner/actions/workflows/spell-check.yml)
 
 ROS driver for Scanse Sweep 360° 2D LIDAR.
 

--- a/external/libsweep/v1.3.0/include/queue.hpp
+++ b/external/libsweep/v1.3.0/include/queue.hpp
@@ -41,14 +41,14 @@ public:
     the_cond_var.notify_one();
   }
 
-  // If the queue is empty, wait till an element is avaiable.
+  // If the queue is empty, wait till an element is available.
   T dequeue() {
     std::unique_lock<std::mutex> lock(the_mutex);
     // wait until queue is not empty
     while (the_queue.empty()) {
       // the_cond_var could wake up the thread spontaneously, even if the queue is still empty...
       // so put this wakeup inside a while loop, such that the empty check is performed whenever it wakes up
-      the_cond_var.wait(lock); // release lock as long as the wait and reaquire it afterwards.
+      the_cond_var.wait(lock); // release lock as long as the wait and reacquire it afterwards.
     }
     auto v = std::move(the_queue.front());
     the_queue.pop();

--- a/external/libsweep/v1.3.0/src/sweep.cc
+++ b/external/libsweep/v1.3.0/src/sweep.cc
@@ -83,7 +83,7 @@ static void sweep_device_wait_until_motor_ready(sweep_device_s device, sweep_err
   // (20 iterations with 500ms pause)
   for (int32_t i = 0; i < 20; ++i) {
     if (i > 0) {
-      // only check every 500ms, to avoid unecessary processing if this is executing in a dedicated thread
+      // only check every 500ms, to avoid unnecessary processing if this is executing in a dedicated thread
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 

--- a/external/libsweep/v1.3.0/src/win/serial.cc
+++ b/external/libsweep/v1.3.0/src/win/serial.cc
@@ -187,7 +187,7 @@ void device_read(device_s serial, void* to, int32_t len) {
         f_result = true;
       }
 
-      //  Reset flag so that another opertion can be issued.
+      //  Reset flag so that another operation can be issued.
       serial->waiting_on_read = false;
       break;
 

--- a/src/SweepScannerNode.cpp
+++ b/src/SweepScannerNode.cpp
@@ -69,7 +69,7 @@ void SweepScannerNode::scannerThreadFunc() try
   _scanner->set_sample_rate(_sample_rate);
   _scanner->start_scanning();
 
-  RCLCPP_INFO(get_logger(), "starting data aquisition.");
+  RCLCPP_INFO(get_logger(), "starting data acquisition.");
 
   while (_scanner_thread_active)
   {


### PR DESCRIPTION
On every push, pull request, and periodically, use the codespell-project/actions-codespell action to check for commonly
misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the ignore-words-list field
of ./.codespellrc. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore
list. The ignore list is comma-separated with no spaces.